### PR TITLE
Drop ObjectReference fields that don't make sense from exemplar

### DIFF
--- a/exemplar-crd/service.binding_servicebindings.yaml
+++ b/exemplar-crd/service.binding_servicebindings.yaml
@@ -62,31 +62,11 @@ spec:
                       - type: string
                       x-kubernetes-int-or-string: true
                     type: array
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
                   kind:
                     description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                     type: string
                   selector:
                     description: Selector is a query that selects the application
@@ -133,9 +113,6 @@ spec:
                           "value". The requirements are ANDed.
                         type: object
                     type: object
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
                 type: object
               env:
                 description: EnvVars is the collection of mappings from Secret entries
@@ -190,34 +167,11 @@ spec:
                   apiVersion:
                     description: API version of the referent.
                     type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
                   kind:
                     description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
                 type: object
               type:

--- a/exemplar-crd/service_binding.go
+++ b/exemplar-crd/service_binding.go
@@ -22,13 +22,33 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// ServiceBindingApplication defines an extension to v1.ObjectReference
-type ServiceBindingApplication struct {
-	corev1.ObjectReference `json:",inline"`
+// ServiceBindingApplicationReference defines a subset of corev1.ObjectReference with extensions
+type ServiceBindingApplicationReference struct {
+	ObjectReference `json:",inline"`
 	// Containers describes which containers in a Pod should be bound to
 	Containers []intstr.IntOrString `json:"containers,omitempty"`
 	// Selector is a query that selects the application or applications to bind the service to
 	Selector metav1.LabelSelector `json:"selector,omitempty"`
+}
+
+// ServiceBindingServiceReference defines a subset of corev1.ObjectReference
+type ServiceBindingServiceReference struct {
+	ObjectReference `json:",inline"`
+}
+
+// ObjectReference is a subset of corev1.ObjectReference
+type ObjectReference struct {
+	// API version of the referent.
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty"`
+	// Kind of the referent.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+	// +optional
+	Kind string `json:"kind,omitempty"`
+	// Name of the referent.
+	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+	// +optional
+	Name string `json:"name,omitempty"`
 }
 
 // ServiceBindingEnvVar defines a mapping from the value of a Secret entry to an environment variable
@@ -57,9 +77,9 @@ type ServiceBindingSpec struct {
 	// Provider is the provider of the service as projected into the application container
 	Provider string `json:"provider,omitempty"`
 	// Application is a reference to an object that fulfills the PodSpec duck type
-	Application ServiceBindingApplication `json:"application"`
+	Application ServiceBindingApplicationReference `json:"application"`
 	// Service is a reference to an object that fulfills the ProvisionedService duck type
-	Service corev1.ObjectReference `json:"service"`
+	Service ServiceBindingServiceReference `json:"service"`
 	// EnvVars is the collection of mappings from Secret entries to environment variables
 	EnvVars []ServiceBindingEnvVar `json:"env,omitempty"`
 	// Mappings is the collection of mappings from existing Secret entries to new Secret entries

--- a/exemplar-crd/service_binding.go
+++ b/exemplar-crd/service_binding.go
@@ -39,15 +39,12 @@ type ServiceBindingServiceReference struct {
 // ObjectReference is a subset of corev1.ObjectReference
 type ObjectReference struct {
 	// API version of the referent.
-	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Kind of the referent.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-	// +optional
 	Kind string `json:"kind,omitempty"`
 	// Name of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-	// +optional
 	Name string `json:"name,omitempty"`
 }
 


### PR DESCRIPTION
We only use/need:
- apiVersion
- kind
- name

Implementations can still use `corev1.ObjectReference` and just not use the additional fields.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>