### PR TITLE
v1alpha2

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ A Service Binding resource **MUST** define a `.status.conditions` which is an ar
 ## Resource Type Schema
 
 ```yaml
-apiVersion: service.binding/v1alpha1
+apiVersion: service.binding/v1alpha2
 kind: ServiceBinding
 metadata:
   name:                 # string
@@ -230,7 +230,7 @@ status:
 ## Minimal Example Resource
 
 ```yaml
-apiVersion: service.binding/v1alpha1
+apiVersion: service.binding/v1alpha2
 kind: ServiceBinding
 metadata:
   name: account-service
@@ -254,7 +254,7 @@ status:
 ## Label Selector Example Resource
 
 ```yaml
-apiVersion: service.binding/v1alpha1
+apiVersion: service.binding/v1alpha2
 kind: ServiceBinding
 metadata:
   name: online-banking-frontend-to-account-service
@@ -283,7 +283,7 @@ status:
 ## Mappings Example Resource
 
 ```yaml
-apiVersion: service.binding/v1alpha1
+apiVersion: service.binding/v1alpha2
 kind: ServiceBinding
 metadata:
   name: account-service
@@ -313,7 +313,7 @@ status:
 ## Environment Variables Example Resource
 
 ```yaml
-apiVersion: service.binding/v1alpha1
+apiVersion: service.binding/v1alpha2
 kind: ServiceBinding
 metadata:
   name: account-service

--- a/internal/v1alpha2/group_version.go
+++ b/internal/v1alpha2/group_version.go
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-// Package v1alpha1 contains API Schema definitions for the service v1alpha1 API group
+// Package v1alpha2 contains API Schema definitions for the service v1alpha2 API group
 // +kubebuilder:object:generate=true
 // +groupName=service.binding
-package v1alpha1
+package v1alpha2
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "service.binding", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "service.binding", Version: "v1alpha2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/internal/v1alpha2/service_binding.go
+++ b/internal/v1alpha2/service_binding.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v1alpha1
+package v1alpha2
 
 import (
 	corev1 "k8s.io/api/core/v1"

--- a/service.binding_servicebindings.yaml
+++ b/service.binding_servicebindings.yaml
@@ -26,7 +26,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1alpha1
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: ServiceBinding is the Schema for the servicebindings API


### PR DESCRIPTION
Per discussions in the working group, this first exemplar CRD will be v1alpha2 because of its distance from the specification as originally conceived.

**NOTE**: in the future versions will be added, not replaced, in the CRD.  This was a special case where I'd created something called `v1alpha1` that was _not_ that and therefore had to be moved, not added to.

[resolves #69]
