### PR TITLE
Remove redundant constraint about same namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ An implementation is not compliant if it fails to satisfy one or more of the MUS
 
 # Provisioned Service
 
-A Provisioned Service resource **MUST** define a `.status.binding.name` which is a `LocalObjectReference`-able to a `Secret`.  The `Secret` **MUST** be in the same namespace as the resource.  The `Secret` **SHOULD** contain a `type` entry with a value that identifies the abstract classification of the binding.  It is **RECOMMENDED** that the `Secret` also contain a `provider` entry with a value that identifies the provider of the binding.  The `Secret` **MAY** contain any other entry.
+A Provisioned Service resource **MUST** define a `.status.binding.name` which is a `LocalObjectReference`-able to a `Secret`.  The `Secret` **SHOULD** contain a `type` entry with a value that identifies the abstract classification of the binding.  It is **RECOMMENDED** that the `Secret` also contain a `provider` entry with a value that identifies the provider of the binding.  The `Secret` **MAY** contain any other entry.
 
 Extensions and implementations **MAY** define additional mechanisms to consume a Provisioned Service that does not conform to the duck type.
 


### PR DESCRIPTION
LocalObjectReference always refers to a resource in the same namespace.

From https://pkg.go.dev/k8s.io/api/core/v1#LocalObjectReference

  "LocalObjectReference contains enough information to let you locate
  the referenced object inside the same namespace."

Signed-off-by: Baiju Muthukadan <baiju.m.mail@gmail.com>