### PR TITLE
Replace EnvVar with EnvMapping to avoid ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The Service Binding resource **MAY** define `.spec.application.containers`, as a
 
 A Service Binding Resource **MAY** define a `.spec.mappings` which is an array of `Mapping` objects.  A `Mapping` object **MUST** define `name` and `value` entries.  The `value` of a `Mapping` **MUST** be handled as a [Go Template][gt] exposing binding `Secret` keys for substitution. The executed output of the template **MUST** be added to the `Secret` exposed to the resource represented by `application` as the key specified by the `name` of the `Mapping`.
 
-A Service Binding Resource **MAY** define a `.spec.env` which is an array of `EnvVar`.  An `EnvVar` object **MUST** define `name` and `key` entries.  The `key` of an `EnvVar` **MUST** refer to a binding `Secret` key name including any key defined by a `Mapping`.  The value of this `Secret` entry **MUST** be configured as an environment variable on the resource represented by `application`.
+A Service Binding Resource **MAY** define a `.spec.env` which is an array of `EnvMapping`.  An `EnvMapping` object **MUST** define `name` and `key` entries.  The `key` of an `EnvMapping` **MUST** refer to a binding `Secret` key name including any key defined by a `Mapping`.  The value of this `Secret` entry **MUST** be configured as an environment variable on the resource represented by `application`.
 
 A Service Binding resource **MUST** define a `.status.conditions` which is an array of `Condition` objects.  A `Condition` object **MUST** define `type`, `status`, and `lastTransitionTime` entries.  At least one condition containing a `type` of `Ready` **MUST** be defined.  The `status` of the `Ready` condition **MUST** have a value of `True`, `False`, or `Unknown`.  The `lastTransitionTime` **MUST** contain the last time that the condition transitioned from one status to another.  A Service Binding resource **MAY** define `reason` and `message` entries to describe the last `status` transition.  As label selectors are inherently queries that return zero-to-many resources, it is **RECOMMENDED** that `ServiceBinding` authors use a combination of labels that yield a single resource, but implementors **MUST** handle each matching resource as if it was specified by name in a distinct `ServiceBinding` resource. Partial failures **MUST** be aggregated and reported on the binding status's `Ready` condition. A Service Binding resource **SHOULD** reflect the secret projected into the application as `.status.binding.name`.
 
@@ -242,7 +242,7 @@ spec:
   - name:               # string
     value:              # string
 
-  env:                  # []EnvVar, optional
+  env:                  # []EnvMapping, optional
   - name:               # string
     key:                # string
 
@@ -464,7 +464,7 @@ spec:
     selector:           # metav1.LabelSelector, mutually exclusive with name
     containers:         # []intstr.IntOrString, optional
 
-  env:                  # []EnvVar, optional
+  env:                  # []EnvMapping, optional
   - name:               # string
     key:                # string
 

--- a/internal.service.binding_servicebindingprojections.yaml
+++ b/internal.service.binding_servicebindingprojections.yaml
@@ -129,10 +129,10 @@ spec:
                 - name
                 type: object
               env:
-                description: EnvVars is the collection of mappings from Secret entries
+                description: Env is the collection of mappings from Secret entries
                   to environment variables
                 items:
-                  description: ServiceBindingProjectionEnvVar defines a mapping from
+                  description: EnvMapping defines a mapping from
                     the value of a Secret entry to an environment variable
                   properties:
                     key:

--- a/internal/internal.service.binding/v1alpha2/service_binding_projection.go
+++ b/internal/internal.service.binding/v1alpha2/service_binding_projection.go
@@ -45,8 +45,8 @@ type ServiceBindingProjectionApplicationReference struct {
 	Containers []intstr.IntOrString `json:"containers,omitempty"`
 }
 
-// ServiceBindingProjectionEnvVar defines a mapping from the value of a Secret entry to an environment variable
-type ServiceBindingProjectionEnvVar struct {
+// EnvMapping defines a mapping from the value of a Secret entry to an environment variable
+type EnvMapping struct {
 	// Name is the name of the environment variable
 	Name string `json:"name"`
 	// Key is the key in the Secret that will be exposed
@@ -61,8 +61,8 @@ type ServiceBindingProjectionSpec struct {
 	Binding ServiceBindingProjectionSecretReference `json:"binding"`
 	// Application is a reference to an object that fulfills the PodSpec duck type
 	Application ServiceBindingProjectionApplicationReference `json:"application"`
-	// EnvVars is the collection of mappings from Secret entries to environment variables
-	EnvVars []ServiceBindingProjectionEnvVar `json:"env,omitempty"`
+	// Env is the collection of mappings from Secret entries to environment variables
+	Env []EnvMapping `json:"env,omitempty"`
 }
 
 // ServiceBindingProjectionConditionType is a valid value for ServiceBindingProjectionCondition.Type
@@ -98,7 +98,6 @@ type ServiceBindingProjectionStatus struct {
 
 	// Conditions are the conditions of this ServiceBindingProjection
 	Conditions []ServiceBindingProjectionCondition `json:"conditions,omitempty"`
-
 }
 
 // +kubebuilder:object:root=true

--- a/internal/service.binding/v1alpha2/service_binding.go
+++ b/internal/service.binding/v1alpha2/service_binding.go
@@ -57,8 +57,8 @@ type ServiceBindingSecretReference struct {
 	Name string `json:"name"`
 }
 
-// ServiceBindingEnvVar defines a mapping from the value of a Secret entry to an environment variable
-type ServiceBindingEnvVar struct {
+// EnvMapping defines a mapping from the value of a Secret entry to an environment variable
+type EnvMapping struct {
 	// Name is the name of the environment variable
 	Name string `json:"name"`
 	// Key is the key in the Secret that will be exposed
@@ -86,8 +86,8 @@ type ServiceBindingSpec struct {
 	Application ServiceBindingApplicationReference `json:"application"`
 	// Service is a reference to an object that fulfills the ProvisionedService duck type
 	Service ServiceBindingServiceReference `json:"service"`
-	// EnvVars is the collection of mappings from Secret entries to environment variables
-	EnvVars []ServiceBindingEnvVar `json:"env,omitempty"`
+	// Env is the collection of mappings from Secret entries to environment variables
+	Env []EnvMapping `json:"env,omitempty"`
 	// Mappings is the collection of mappings from existing Secret entries to new Secret entries
 	Mappings []ServiceBindingMapping `json:"mappings,omitempty"`
 }

--- a/service.binding_servicebindings.yaml
+++ b/service.binding_servicebindings.yaml
@@ -118,10 +118,10 @@ spec:
                 - kind
                 type: object
               env:
-                description: EnvVars is the collection of mappings from Secret entries
+                description: Env is the collection of mappings from Secret entries
                   to environment variables
                 items:
-                  description: ServiceBindingEnvVar defines a mapping from the value
+                  description: EnvMapping defines a mapping from the value
                     of a Secret entry to an environment variable
                   properties:
                     key:


### PR DESCRIPTION
There is a `corev1.EnvVar` which is different from the values of `Env`.

Signed-off-by: Baiju Muthukadan <baiju.m.mail@gmail.com>