### PR TITLE
Limit containers scoping to names

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,9 @@ Restricting service binding to resources within the same namespace is strongly *
 
 A Service Binding resource **MUST** define a `.spec.application` which is an `ObjectReference`-like declaration to a `PodSpec`-able resource.  A `ServiceBinding` **MAY** define the application reference by-name or by-[label selector][ls]. A name and selector **MUST NOT** be defined in the same reference.  A Service Binding resource **MUST** define a `.spec.service` which is an `ObjectReference`-like declaration to a Provisioned Service-able resource.  Extensions and implementations **MAY** allow additional kinds of applications and services to be referenced.
 
-The Service Binding resource **MAY** define `.spec.application.containers`, as a list of integers or strings, to limit which containers in the application are bound.  Binding to a container is opt-in, unless `.spec.application.containers` is undefined then all containers **MUST** be bound.  For each item in the containers list:
-- if the value is an integer (`${containerInteger}`), the container matching by index (`.spec.template.spec.containers[${containerInteger}]`) **MUST** be bound. Init containers **MUST NOT** be bound
-- if the value is a string (`${containerString}`), a container or init container matching by name (`.spec.template.spec.containers[?(@.name=='${containerString}')]` or `.spec.template.spec.initContainers[?(@.name=='${containerString}')]`) **MUST** be bound
+The Service Binding resource **MAY** define `.spec.application.containers`, as a list of strings, to limit which containers in the application are bound.  Binding to a container is opt-in, unless `.spec.application.containers` is undefined then all containers **MUST** be bound.  For each item in the containers list:
+- a container or init container matching by name (`.spec.template.spec.containers[?(@.name=='${containerName}')]` or `.spec.template.spec.initContainers[?(@.name=='${containerName}')]`) **MUST** be bound
 - values that do not match a container or init container **SHOULD** be ignored
-
 
 A Service Binding Resource **MAY** define a `.spec.mappings` which is an array of `Mapping` objects.  A `Mapping` object **MUST** define `name` and `value` entries.  The `value` of a `Mapping` **MUST** be handled as a [Go Template][gt] exposing binding `Secret` keys for substitution. The executed output of the template **MUST** be added to the `Secret` exposed to the resource represented by `application` as the key specified by the `name` of the `Mapping`.
 
@@ -231,7 +229,7 @@ spec:
     kind:               # string
     name:               # string, mutually exclusive with selector
     selector:           # metav1.LabelSelector, mutually exclusive with name
-    containers:         # []intstr.IntOrString, optional
+    containers:         # []string, optional
 
   service:              # Provisioned Service resource ObjectReference-like
     apiVersion:         # string
@@ -462,7 +460,7 @@ spec:
     kind:               # string
     name:               # string, mutually exclusive with selector
     selector:           # metav1.LabelSelector, mutually exclusive with name
-    containers:         # []intstr.IntOrString, optional
+    containers:         # []string, optional
 
   env:                  # []EnvVar, optional
   - name:               # string

--- a/internal.service.binding_servicebindingprojections.yaml
+++ b/internal.service.binding_servicebindingprojections.yaml
@@ -59,10 +59,7 @@ spec:
                     description: Containers describes which containers in a Pod should
                       be bound to
                     items:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      x-kubernetes-int-or-string: true
+                      type: string
                     type: array
                   kind:
                     description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'

--- a/internal/internal.service.binding/v1alpha2/service_binding_projection.go
+++ b/internal/internal.service.binding/v1alpha2/service_binding_projection.go
@@ -19,7 +19,6 @@ package v1alpha2
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // ServiceBindingProjectionSecretReference defines a mirror of corev1.LocalObjectReference
@@ -42,7 +41,7 @@ type ServiceBindingProjectionApplicationReference struct {
 	// Selector is a query that selects the application or applications to bind the service to
 	Selector metav1.LabelSelector `json:"selector,omitempty"`
 	// Containers describes which containers in a Pod should be bound to
-	Containers []intstr.IntOrString `json:"containers,omitempty"`
+	Containers []string `json:"containers,omitempty"`
 }
 
 // ServiceBindingProjectionEnvVar defines a mapping from the value of a Secret entry to an environment variable
@@ -98,7 +97,6 @@ type ServiceBindingProjectionStatus struct {
 
 	// Conditions are the conditions of this ServiceBindingProjection
 	Conditions []ServiceBindingProjectionCondition `json:"conditions,omitempty"`
-
 }
 
 // +kubebuilder:object:root=true

--- a/internal/service.binding/v1alpha2/service_binding.go
+++ b/internal/service.binding/v1alpha2/service_binding.go
@@ -19,7 +19,6 @@ package v1alpha2
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // ServiceBindingApplicationReference defines a subset of corev1.ObjectReference with extensions
@@ -35,7 +34,7 @@ type ServiceBindingApplicationReference struct {
 	// Selector is a query that selects the application or applications to bind the service to
 	Selector metav1.LabelSelector `json:"selector,omitempty"`
 	// Containers describes which containers in a Pod should be bound to
-	Containers []intstr.IntOrString `json:"containers,omitempty"`
+	Containers []string `json:"containers,omitempty"`
 }
 
 // ServiceBindingServiceReference defines a subset of corev1.ObjectReference

--- a/service.binding_servicebindings.yaml
+++ b/service.binding_servicebindings.yaml
@@ -57,10 +57,7 @@ spec:
                     description: Containers describes which containers in a Pod should
                       be bound to
                     items:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      x-kubernetes-int-or-string: true
+                      type: string
                     type: array
                   kind:
                     description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'


### PR DESCRIPTION
Fixes #127

> Referencing containers by index is fragile in the presence of admission
> webhooks that inject sidecar containers. Referencing by name would be
> much more stable.

Signed-off-by: Baiju Muthukadan <baiju.m.mail@gmail.com>