### PR TITLE
Remove PodSpec-able restriction

### DIFF
--- a/internal/service.binding/v1alpha2/service_binding.go
+++ b/internal/service.binding/v1alpha2/service_binding.go
@@ -82,7 +82,7 @@ type ServiceBindingSpec struct {
 	Type string `json:"type,omitempty"`
 	// Provider is the provider of the service as projected into the application container
 	Provider string `json:"provider,omitempty"`
-	// Application is a reference to an object that fulfills the PodSpec duck type
+	// Application is a reference to an object
 	Application ServiceBindingApplicationReference `json:"application"`
 	// Service is a reference to an object that fulfills the ProvisionedService duck type
 	Service ServiceBindingServiceReference `json:"service"`

--- a/service.binding_servicebindings.yaml
+++ b/service.binding_servicebindings.yaml
@@ -47,8 +47,7 @@ spec:
             description: ServiceBindingSpec defines the desired state of ServiceBinding
             properties:
               application:
-                description: Application is a reference to an object that fulfills
-                  the PodSpec duck type
+                description: Application is a reference to an object
                 properties:
                   apiVersion:
                     description: API version of the referent.


### PR DESCRIPTION
The addition of the Application Resource Mapping extension specification allows us to create a low-effort, cluster-wide mapping of the Service Binding onto any reasonable (containing env, volumeMount, and volume concepts) resource type.  Given this new ability, it makes no sense for the core specification to be restricted to targeting only PodSpec-able resources.

This change promotes the Application Resource Mapping extension to be part of the core specification.  It also removes the restrictions in other parts of the specification that required that application's be PodSpec-able.
