### PR TITLE
Rename "Application" to "Workload"

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ An implementation is not compliant if it fails to satisfy one or more of the MUS
   <dd>Any software that exposes functionality.  Examples include a database, a message broker, a workload with REST endpoints, an event stream, an Application Performance Monitor, or a Hardware Security Module.</dd>
 
   <dt>Workload</dt>
-  <dd>A <a href="https://kubernetes.io/docs/concepts/workloads/">workload</a> is an application running on Kubernetes..  Examples include processing using a framework like Spring Boot, NodeJS Express, or Ruby Rails. Workloads are the part of an application that runs. Workloads may colloquially be referred to as an application.</dd>
+  <dd>A <a href="https://kubernetes.io/docs/concepts/workloads/">workload</a> is an application running on Kubernetes.  Examples include processing using a framework like Spring Boot, NodeJS Express, or Ruby Rails. Workloads are the part of an application that runs. Workloads may colloquially be referred to as an application.</dd>
 
   <dt>Service Binding</dt>
   <dd>The act of or representation of the action of providing information about a Service to a workload</dd>

--- a/internal/service.binding/v1alpha2/cluster_workload_resource_mapping.go
+++ b/internal/service.binding/v1alpha2/cluster_workload_resource_mapping.go
@@ -18,9 +18,9 @@ package v1alpha2
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// ClusterApplicationResourceMappingVersion defines the mapping for a specific version of an application resource.
-type ClusterApplicationResourceMappingVersion struct {
-	// Version is the version of the application resource that this mapping is for.
+// ClusterWorkloadResourceMappingVersion defines the mapping for a specific version of a workload resource.
+type ClusterWorkloadResourceMappingVersion struct {
+	// Version is the version of the workload resource that this mapping is for.
 	Version string `json:"version"`
 	// Containers is the collection of JSONPaths that container configuration may be written to.
 	Containers []string `json:"containers,omitempty"`
@@ -32,10 +32,10 @@ type ClusterApplicationResourceMappingVersion struct {
 	Volumes string `json:"volumes"`
 }
 
-// ClusterApplicationResourceMappingSpec defines the desired state of ClusterApplicationResourceMapping
-type ClusterApplicationResourceMappingSpec struct {
+// ClusterWorkloadResourceMappingSpec defines the desired state of ClusterWorkloadResourceMapping
+type ClusterWorkloadResourceMappingSpec struct {
 	// Versions is the collection of versions for a given resource, with mappings.
-	Versions []ClusterApplicationResourceMappingVersion `json:"versions,omitempty"`
+	Versions []ClusterWorkloadResourceMappingVersion `json:"versions,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -43,20 +43,20 @@ type ClusterApplicationResourceMappingSpec struct {
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
-// ClusterApplicationResourceMapping is the Schema for the clusterapplicationresourcemappings API
-type ClusterApplicationResourceMapping struct {
+// ClusterWorkloadResourceMapping is the Schema for the clusterworkloadresourcemappings API
+type ClusterWorkloadResourceMapping struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec ClusterApplicationResourceMappingSpec `json:"spec,omitempty"`
+	Spec ClusterWorkloadResourceMappingSpec `json:"spec,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 
-// ClusterApplicationResourceMappingList contains a list of ClusterApplicationResourceMapping
-type ClusterApplicationResourceMappingList struct {
+// ClusterWorkloadResourceMappingList contains a list of ClusterWorkloadResourceMapping
+type ClusterWorkloadResourceMappingList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
-	Items []ClusterApplicationResourceMapping `json:"items"`
+	Items []ClusterWorkloadResourceMapping `json:"items"`
 }

--- a/internal/service.binding/v1alpha2/service_binding.go
+++ b/internal/service.binding/v1alpha2/service_binding.go
@@ -20,8 +20,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ServiceBindingApplicationReference defines a subset of corev1.ObjectReference with extensions
-type ServiceBindingApplicationReference struct {
+// ServiceBindingWorkloadReference defines a subset of corev1.ObjectReference with extensions
+type ServiceBindingWorkloadReference struct {
 	// API version of the referent.
 	APIVersion string `json:"apiVersion"`
 	// Kind of the referent.
@@ -30,7 +30,7 @@ type ServiceBindingApplicationReference struct {
 	// Name of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	Name string `json:"name,omitempty"`
-	// Selector is a query that selects the application or applications to bind the service to
+	// Selector is a query that selects the workload or workloads to bind the service to
 	Selector metav1.LabelSelector `json:"selector,omitempty"`
 	// Containers describes which containers in a Pod should be bound to
 	Containers []string `json:"containers,omitempty"`
@@ -65,14 +65,14 @@ type EnvMapping struct {
 
 // ServiceBindingSpec defines the desired state of ServiceBinding
 type ServiceBindingSpec struct {
-	// Name is the name of the service as projected into the application container.  Defaults to .metadata.name.
+	// Name is the name of the service as projected into the workload container.  Defaults to .metadata.name.
 	Name string `json:"name,omitempty"`
-	// Type is the type of the service as projected into the application container
+	// Type is the type of the service as projected into the workload container
 	Type string `json:"type,omitempty"`
-	// Provider is the provider of the service as projected into the application container
+	// Provider is the provider of the service as projected into the workload container
 	Provider string `json:"provider,omitempty"`
-	// Application is a reference to an object
-	Application ServiceBindingApplicationReference `json:"application"`
+	// Workload is a reference to an object
+	Workload ServiceBindingWorkloadReference `json:"workload"`
 	// Service is a reference to an object that fulfills the ProvisionedService duck type
 	Service ServiceBindingServiceReference `json:"service"`
 	// Env is the collection of mappings from Secret entries to environment variables
@@ -82,8 +82,8 @@ type ServiceBindingSpec struct {
 // These are valid conditions of ServiceBinding.
 const (
 	// ServiceBindingReady means the ServiceBinding has projected the ProvisionedService
-	// secret and the Application is ready to start. It does not indicate the condition
-	// of either the Service or the Application resources referenced.
+	// secret and the Workload is ready to start. It does not indicate the condition
+	// of either the Service or the Workload resources referenced.
 	ServiceBindingConditionReady = "Ready"
 )
 

--- a/service.binding_clusterworkloadresourcemappings.yaml
+++ b/service.binding_clusterworkloadresourcemappings.yaml
@@ -6,14 +6,14 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
-  name: clusterapplicationresourcemappings.service.binding
+  name: clusterworkloadresourcemappings.service.binding
 spec:
   group: service.binding
   names:
-    kind: ClusterApplicationResourceMapping
-    listKind: ClusterApplicationResourceMappingList
-    plural: clusterapplicationresourcemappings
-    singular: clusterapplicationresourcemapping
+    kind: ClusterWorkloadResourceMapping
+    listKind: ClusterWorkloadResourceMappingList
+    plural: clusterworkloadresourcemappings
+    singular: clusterworkloadresourcemapping
   scope: Cluster
   versions:
   - additionalPrinterColumns:
@@ -23,7 +23,7 @@ spec:
     name: v1alpha2
     schema:
       openAPIV3Schema:
-        description: ClusterApplicationResourceMapping is the Schema for the clusterapplicationresourcemappings API
+        description: ClusterWorkloadResourceMapping is the Schema for the clusterworkloadresourcemappings API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -34,12 +34,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: ClusterApplicationResourceMappingSpec defines the desired state of ClusterApplicationResourceMapping
+            description: ClusterWorkloadResourceMappingSpec defines the desired state of ClusterWorkloadResourceMapping
             properties:
               versions:
                 description: Versions is the collection of versions for a given resource, with mappings.
                 items:
-                  description: ClusterApplicationResourceMappingVersion defines the mapping for a specific version of an application resource.
+                  description: ClusterWorkloadResourceMappingVersion defines the mapping for a specific version of a workload resource.
                   properties:
                     containers:
                       description: Containers is the collection of JSONPaths that container configuration may be written to.
@@ -52,7 +52,7 @@ spec:
                         type: string
                       type: array
                     version:
-                      description: Version is the version of the application resource that this mapping is for.
+                      description: Version is the version of the workload resource that this mapping is for.
                       type: string
                     volumeMounts:
                       description: VolumeMounts is the collection of JSONPaths that volume mount configuration may be written to.

--- a/service.binding_servicebindings.yaml
+++ b/service.binding_servicebindings.yaml
@@ -42,8 +42,50 @@ spec:
           spec:
             description: ServiceBindingSpec defines the desired state of ServiceBinding
             properties:
-              application:
-                description: Application is a reference to an object
+              env:
+                description: Env is the collection of mappings from Secret entries to environment variables
+                items:
+                  description: EnvMapping defines a mapping from the value of a Secret entry to an environment variable
+                  properties:
+                    key:
+                      description: Key is the key in the Secret that will be exposed
+                      type: string
+                    name:
+                      description: Name is the name of the environment variable
+                      type: string
+                  required:
+                  - key
+                  - name
+                  type: object
+                type: array
+              name:
+                description: Name is the name of the service as projected into the workload container.  Defaults to .metadata.name.
+                type: string
+              provider:
+                description: Provider is the provider of the service as projected into the workload container
+                type: string
+              service:
+                description: Service is a reference to an object that fulfills the ProvisionedService duck type
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+              type:
+                description: Type is the type of the service as projected into the workload container
+                type: string
+              workload:
+                description: Workload is a reference to an object
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -60,7 +102,7 @@ spec:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
                   selector:
-                    description: Selector is a query that selects the application or applications to bind the service to
+                    description: Selector is a query that selects the workload or workloads to bind the service to
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -93,51 +135,9 @@ spec:
                 - apiVersion
                 - kind
                 type: object
-              env:
-                description: Env is the collection of mappings from Secret entries to environment variables
-                items:
-                  description: EnvMapping defines a mapping from the value of a Secret entry to an environment variable
-                  properties:
-                    key:
-                      description: Key is the key in the Secret that will be exposed
-                      type: string
-                    name:
-                      description: Name is the name of the environment variable
-                      type: string
-                  required:
-                  - key
-                  - name
-                  type: object
-                type: array
-              name:
-                description: Name is the name of the service as projected into the application container.  Defaults to .metadata.name.
-                type: string
-              provider:
-                description: Provider is the provider of the service as projected into the application container
-                type: string
-              service:
-                description: Service is a reference to an object that fulfills the ProvisionedService duck type
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                required:
-                - apiVersion
-                - kind
-                - name
-                type: object
-              type:
-                description: Type is the type of the service as projected into the application container
-                type: string
             required:
-            - application
             - service
+            - workload
             type: object
           status:
             description: ServiceBindingStatus defines the observed state of ServiceBinding


### PR DESCRIPTION
In Kubernetes an application[[1](https://github.com/kubernetes-sigs/application)][[2](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels)] is a loose collection of workloads[[3](https://kubernetes.io/docs/reference/kubernetes-api/workloads-resources/)] and
accompaning resources. What we have been refering to as "applications"
are technically "workloads".

Every semantic reference to application has been updated except for
common phrases like "application developer" and "application performance
monitoring".