### PR TITLE
feat: allow users to define static key-value pairs in Service Binding…

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,3 +799,8 @@ status:
     “service.binding/endpoints”:
       "path={.status.bootstrap},elementType=sliceOfMaps,sourceKey=type,sourceValue=url"
     ```
+1.  Mount a static key-value pair into the binding `Secret`
+    ```plain
+    “service.binding/key”:
+      "value={GO_TEMPLATE}"
+    ```


### PR DESCRIPTION
… annotations (#140)

This is especially useful when defining Service Binding annotations in CRDs who's value are the same across all CRs. For example, the `type` and `provider` will be the same for Databases or [Kafka](https://github.com/quarkusio/quarkus/issues/15631#issuecomment-799305457) brokers etc ...


Thanks !