### PR TITLE
Remove mappings from the ServiceBinding resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,11 @@ rules:
 
 # Application Projection
 
-A Binding `Secret` **MUST** be volume mounted into a container at `$SERVICE_BINDING_ROOT/<binding-name>` with directory names matching the name of the binding.  Binding names **MUST** match `[a-z0-9\-\.]{1,253}`.  The `$SERVICE_BINDING_ROOT` environment variable **MUST** be declared and can point to any valid file system location.
+A projected binding **MUST** be volume mounted into a container at `$SERVICE_BINDING_ROOT/<binding-name>` with directory names matching the name of the binding.  Binding names **MUST** match `[a-z0-9\-\.]{1,253}`.  The `$SERVICE_BINDING_ROOT` environment variable **MUST** be declared and can point to any valid file system location.
 
-The `Secret` data **MUST** contain a `type` entry with a value that identifies the abstract classification of the binding.  The `Secret` type (`.type` verses `.data.type`) **MUST** reflect this value as `service.binding/{type}`, replacing `{type}` with the `Secret` data type.  It is **RECOMMENDED** that the `Secret` data also contain a `provider` entry with a value that identifies the provider of the binding.  The `Secret` data **MAY** contain any other entry.
+The projected binding **MUST** contain a `type` entry with a value that identifies the abstract classification of the binding.  It is **RECOMMENDED** that the projected binding also contain a `provider` entry with a value that identifies the provider of the binding.  The projected binding data **MAY** contain any other entry.
 
-The name of a secret entry file name **SHOULD** match `[a-z0-9\-\.]{1,253}`.  The contents of a secret entry may be anything representable as bytes on the file system including, but not limited to, a literal string value (e.g. `db-password`), a language-specific binary (e.g. a Java `KeyStore` with a private key and X.509 certificate), or an indirect pointer to another system for value resolution (e.g. `vault://production-database/password`).
+The name of a binding entry file name **SHOULD** match `[a-z0-9\-\.]{1,253}`.  The contents of a binding entry may be anything representable as bytes on the file system including, but not limited to, a literal string value (e.g. `db-password`), a language-specific binary (e.g. a Java `KeyStore` with a private key and X.509 certificate), or an indirect pointer to another system for value resolution (e.g. `vault://production-database/password`).
 
 The collection of files within the directory **MAY** change between container launches.  The collection of files within the directory **SHOULD NOT** change during the lifetime of the container.
 
@@ -284,6 +284,8 @@ metadata:
   ...
 spec:
   name:                 # string, optional, default: .metadata.name
+  type:                 # string, optional
+  provider:             # string, optional
 
   application:          # ObjectReference-like
     apiVersion:         # string
@@ -413,6 +415,8 @@ If a `.spec.name` is set, the directory name of the volume mount **MUST** be its
 If the `$SERVICE_BINDING_ROOT` environment variable has already been configured on the resource represented by `application`, the Provisioned Service binding `Secret` **MUST** be mounted relative to that location.  If the `$SERVICE_BINDING_ROOT` environment variable has not been configured on the resource represented by `application`, the `$SERVICE_BINDING_ROOT` environment variable **MUST** be set and the Provisioned Service binding `Secret` **MUST** be mounted relative to that location.  A **RECOMMENDED** value to use is `/bindings`.
 
 The `$SERVICE_BINDING_ROOT` environment variable **MUST NOT** be reset if it is already configured on the resource represented by `application`.
+
+If a `.spec.type` is set, the `type` entry in the application projection **MUST** be set to its value overriding any existing value.  If a `.spec.provider` is set, the `provider` entry in the application projection **MUST** be set to its value overriding any existing value.
 
 ### Ready Condition Status
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ An implementation is not compliant if it fails to satisfy one or more of the MUS
 
 A Provisioned Service resource **MUST** define a `.status.binding` which is a `LocalObjectReference`-able (containing a single field `name`) to a `Secret`.  The `Secret` **MUST** be in the same namespace as the resource.  The `Secret` data **SHOULD** contain a `type` entry with a value that identifies the abstract classification of the binding.  The `Secret` type (`.type` verses `.data.type`) **SHOULD** reflect this value as `service.binding/{type}`, replacing `{type}` with the `Secret` data type.  It is **RECOMMENDED** that the `Secret` data also contain a `provider` entry with a value that identifies the provider of the binding.  The `Secret` data **MAY** contain any other entry.  To facilitate discoverability, it is **RECOMMENDED** that a `CustomResourceDefinition` exposing a Provisioned Service add `service.binding/provisioned-service: "true"` as a label.
 
+> Note: While the Provisioned Service referenced `Secret` data should contain a `type` entry, the `type` must be defined before it is projected into an application workload. This allows a mapping to enrich an existing secret.
+
 Extensions and implementations **MAY** define additional mechanisms to consume a Provisioned Service that does not conform to the duck type.
 
 ## Resource Type Schema

--- a/internal/service.binding/v1alpha2/service_binding.go
+++ b/internal/service.binding/v1alpha2/service_binding.go
@@ -64,31 +64,16 @@ type EnvMapping struct {
 	Key string `json:"key"`
 }
 
-// ServiceBindingMapping defines a mapping from the existing collection of Secret values to a new Secret entry.
-type ServiceBindingMapping struct {
-	// Name is the name of the mapped Secret entry
-	Name string `json:"name"`
-	// Value is the value of the new Secret entry.  Contents may be a Go template and refer to the other secret entries
-	// by name.
-	Value string `json:"value"`
-}
-
 // ServiceBindingSpec defines the desired state of ServiceBinding
 type ServiceBindingSpec struct {
 	// Name is the name of the service as projected into the application container.  Defaults to .metadata.name.
 	Name string `json:"name,omitempty"`
-	// Type is the type of the service as projected into the application container
-	Type string `json:"type,omitempty"`
-	// Provider is the provider of the service as projected into the application container
-	Provider string `json:"provider,omitempty"`
 	// Application is a reference to an object
 	Application ServiceBindingApplicationReference `json:"application"`
 	// Service is a reference to an object that fulfills the ProvisionedService duck type
 	Service ServiceBindingServiceReference `json:"service"`
 	// Env is the collection of mappings from Secret entries to environment variables
 	Env []EnvMapping `json:"env,omitempty"`
-	// Mappings is the collection of mappings from existing Secret entries to new Secret entries
-	Mappings []ServiceBindingMapping `json:"mappings,omitempty"`
 }
 
 // These are valid conditions of ServiceBinding.

--- a/internal/service.binding/v1alpha2/service_binding.go
+++ b/internal/service.binding/v1alpha2/service_binding.go
@@ -68,6 +68,10 @@ type EnvMapping struct {
 type ServiceBindingSpec struct {
 	// Name is the name of the service as projected into the application container.  Defaults to .metadata.name.
 	Name string `json:"name,omitempty"`
+	// Type is the type of the service as projected into the application container
+	Type string `json:"type,omitempty"`
+	// Provider is the provider of the service as projected into the application container
+	Provider string `json:"provider,omitempty"`
 	// Application is a reference to an object
 	Application ServiceBindingApplicationReference `json:"application"`
 	// Service is a reference to an object that fulfills the ProvisionedService duck type

--- a/service.binding_servicebindings.yaml
+++ b/service.binding_servicebindings.yaml
@@ -112,27 +112,8 @@ spec:
                   - name
                   type: object
                 type: array
-              mappings:
-                description: Mappings is the collection of mappings from existing Secret entries to new Secret entries
-                items:
-                  description: ServiceBindingMapping defines a mapping from the existing collection of Secret values to a new Secret entry.
-                  properties:
-                    name:
-                      description: Name is the name of the mapped Secret entry
-                      type: string
-                    value:
-                      description: Value is the value of the new Secret entry.  Contents may be a Go template and refer to the other secret entries by name.
-                      type: string
-                  required:
-                  - name
-                  - value
-                  type: object
-                type: array
               name:
                 description: Name is the name of the service as projected into the application container.  Defaults to .metadata.name.
-                type: string
-              provider:
-                description: Provider is the provider of the service as projected into the application container
                 type: string
               service:
                 description: Service is a reference to an object that fulfills the ProvisionedService duck type
@@ -151,9 +132,6 @@ spec:
                 - kind
                 - name
                 type: object
-              type:
-                description: Type is the type of the service as projected into the application container
-                type: string
             required:
             - application
             - service

--- a/service.binding_servicebindings.yaml
+++ b/service.binding_servicebindings.yaml
@@ -115,6 +115,9 @@ spec:
               name:
                 description: Name is the name of the service as projected into the application container.  Defaults to .metadata.name.
                 type: string
+              provider:
+                description: Provider is the provider of the service as projected into the application container
+                type: string
               service:
                 description: Service is a reference to an object that fulfills the ProvisionedService duck type
                 properties:
@@ -132,6 +135,9 @@ spec:
                 - kind
                 - name
                 type: object
+              type:
+                description: Type is the type of the service as projected into the application container
+                type: string
             required:
             - application
             - service


### PR DESCRIPTION
The existing mappings on the ServiceBinding resource were introduced as
a way to make it easier for a user to enrich an existing Secret into a
form appropriate for binding to an application workload. This approch
had a few issues that can be better addressed by other resources that
interoperate with the ServiceBiding resource. The issues include:
- the ServiceBinding controller needs to be able to read and write
  Secrets
- Go templates were used to compose new values, which worked for basic
  templating, but were limited in their capabilities
- the capabilities of the Go templates are an implemenation detail of
  how the controller is built and could change over time independent of
  the speced behavior.

The behavior applied by mappings can be reintroduced as dedicated
resources that can themselves expose a Secret as a ProvisionedService,
which can be consumed by a ServiceBinding. This change further separates
the concerns of provisioning a service from binding a service.

The `.spec.type` and `.spec.provider` fields are also removed, as
they are syntactic sugar on top of mappings.

Refs #145
Resolves #155 

Signed-off-by: Scott Andrews <andrewssc@vmware.com>