### PR TITLE
Clarify Application Resource Mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,9 +488,9 @@ metadata:
 spec:
   versions:             # []Version
   - version:            # string
-    containers:         # []string, optional
-    envs:               # []string, optional
-    volumeMounts:       # []string, optional
+    containers:         # []string, mutually exclusive with a combination of envs and volumeMounts
+    envs:               # []string, a combination of envs and volumeMounts is mutually exclusive with containers
+    volumeMounts:       # []string, a combination of envs and volumeMounts is mutually exclusive with containers
     volumes:            # string
 ```
 

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ A reconciler implementation **MUST** support mapping to PodSpec-able resources w
 
 If a `ClusterApplicationResourceMapping` defines `containers`, the reconciler **MUST** first resolve a set of candidate locations in the application resource addressed by the `ServiceBinding` using the `Container` type (`.envs`, `.volumeMounts`) for all available containers and then filter that collection by the `ServiceBinding` `.spec.application.containers` filter before applying the appropriate modification.
 
-If a `ClusterApplicationResourceMapping` defines `.envs` and `.volumeMounts`, the reconciler **MUST** first resolve a set of candidate locations in the application resource addressed by the `ServiceBinding` for all available containers and then filter that collection by the `ServiceBinding` `.spec.application.containers` filter before applying the appropriate modification.
+If a `ClusterApplicationResourceMapping` defines `.envs` and `.volumeMounts`, the reconciler **MUST** first resolve a set of candidate locations in the application resource addressed by the `ServiceBinding` and then filter that collection by the `ServiceBinding` `.spec.application.containers` filter before applying the appropriate modification.
 
 If a `ServiceBinding` specifies `.spec.applications.containers` value, that value **MUST** be used to filter all entries in the `.containers` list.  If a `ServiceBinding` specifies a `.spec.applications.containers` value and `ClusterApplicationResourceMapping` for the mapped type defines `.envs` and `.volumeMounts`, the reconciler **MUST** fail to reconcile.
 


### PR DESCRIPTION
-  a combination of `envs` and `volumeMounts` is mutually exclusive
   with containers
- Ignore containers for `.envs` and `.volumeMounts`

Fixes #173

Signed-off-by: Baiju Muthukadan <baiju.m.mail@gmail.com>