### PR TITLE
Drop application label selector

### DIFF
--- a/internal/service.binding/v1alpha2/service_binding.go
+++ b/internal/service.binding/v1alpha2/service_binding.go
@@ -29,9 +29,7 @@ type ServiceBindingApplicationReference struct {
 	Kind string `json:"kind"`
 	// Name of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-	Name string `json:"name,omitempty"`
-	// Selector is a query that selects the application or applications to bind the service to
-	Selector metav1.LabelSelector `json:"selector,omitempty"`
+	Name string `json:"name"`
 	// Containers describes which containers in a Pod should be bound to
 	Containers []string `json:"containers,omitempty"`
 }

--- a/service.binding_servicebindings.yaml
+++ b/service.binding_servicebindings.yaml
@@ -59,39 +59,10 @@ spec:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
-                  selector:
-                    description: Selector is a query that selects the application or applications to bind the service to
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                        type: object
-                    type: object
                 required:
                 - apiVersion
                 - kind
+                - name
                 type: object
               env:
                 description: Env is the collection of mappings from Secret entries to environment variables


### PR DESCRIPTION
ServiceBinding must specify the application to bind by name.

This is a discussion-draft alternative to #179, which is trying to create symmetry between app and service references by adding a label selector to the service reference. This PR creates that same symmetry by removing support for label selectors in application references.